### PR TITLE
Add an openrc file for use in alpine linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 *.out
 
 vendor/
-avahi2dns
+/avahi2dns

--- a/openrc/avahi2dns
+++ b/openrc/avahi2dns
@@ -1,0 +1,8 @@
+#!/sbin/openrc-run
+
+output_logger=logger
+error_logger=logger
+command_background=true
+command="avahi2dns"
+command_args=""
+pidfile="/run/avahi2dns.pid"


### PR DESCRIPTION
With this avahi2dns can be used as a system daemon by coping openrc/avahi2dns to /etc/init.d/avahi2dns and the compiled binary to somewhere in the system path.