### PR TITLE
Don't clear command_args in openrc

### DIFF
--- a/openrc/avahi2dns
+++ b/openrc/avahi2dns
@@ -4,5 +4,4 @@ output_logger=logger
 error_logger=logger
 command_background=true
 command="avahi2dns"
-command_args=""
 pidfile="/run/avahi2dns.pid"


### PR DESCRIPTION
For one, we were not using any arguments, so the variable was unnecessary.

More importantly, that variable should probably be set by the user, in /etc/conf.d/avahi2dns, as documented in

https://wiki.gentoo.org/wiki/Handbook:X86/Working/Initscripts#conf.d_directory

With this I was able to document a way to get printer discovery working on alpine:

https://wiki.alpinelinux.org/wiki/MDNS