### PR TITLE
Add v4 only mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"time"
 
 	"github.com/alexflint/go-arg"
@@ -22,6 +23,7 @@ type config struct {
 	BindAddr string        `arg:"-a,--addr" default:"localhost" help:"address to bind on" env:"BIND"`
 	Port     uint16        `arg:"-p" default:"53" help:"port to bind on" env:"PORT"`
 	Debug    bool          `arg:"-v" default:"false" help:"also include debug information"`
+	V4only   bool          `arg:"-4" default:"false" help:"only resolve A records"`
 	V6only   bool          `arg:"-6" default:"false" help:"only resolve AAAA records"`
 	Timeout  time.Duration `arg:"-t" default:"0s" help:"timeout for the Avahi request, 0 meaning none, see https://pkg.go.dev/time#ParseDuration for units and format"`
 }
@@ -29,6 +31,9 @@ type config struct {
 func parseArgs(logger *logrus.Logger) (*config, error) {
 	cfg := &config{}
 	arg.MustParse(cfg)
+	if cfg.V4only && cfg.V6only {
+		return nil, errors.New("cannot set both --v4only and --v6only")
+	}
 	if len(cfg.Domains) == 0 {
 		cfg.Domains = defaultDomains
 	}

--- a/query.go
+++ b/query.go
@@ -47,6 +47,9 @@ func (me *forwarder) forwardToAvahi(ctx context.Context, r *dns.Msg) *dns.Msg {
 				m.Answer = append(m.Answer, rr)
 
 			case dns.TypeAAAA:
+				if me.v4only {
+					continue
+				}
 				rr, err := me.queryAvahi(ctx, q.Name, avahi.ProtoInet6, "AAAA")
 				if err != nil {
 					me.logger.WithError(err).Error("avahi AAAA lookup failed, skipping query...")

--- a/server.go
+++ b/server.go
@@ -19,6 +19,7 @@ type forwarder struct {
 	mux     *dns.ServeMux
 	ctx     context.Context
 	timeout time.Duration
+	v4only  bool
 	v6only  bool
 }
 
@@ -28,6 +29,7 @@ func NewForwarder(logger *logrus.Logger, cfg *config) (*forwarder, error) {
 		address: fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.Port),
 		mux:     dns.NewServeMux(),
 		timeout: cfg.Timeout,
+		v4only:  cfg.V4only,
 		v6only:  cfg.V6only,
 	}
 


### PR DESCRIPTION
To compliment the existing v6 only mode :slightly_smiling_face: 

I don't have IPv6 on my network and `avahi2dns` will always wait for the full timeout before failing to resolve IPv6 addresses. This additionally seems to cause random failures for various downstream services (e.g. CUPS) since they may receive a timeout rather than the valid IPv4 address.